### PR TITLE
feat(sandbox): orient the repo as a sandbox for agent-authors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,17 +4,23 @@ This file provides guidance to Claude Code when working with this repository.
 
 ## Repository Overview
 
-This is an experiments registry - a Next.js application for creating and showcasing web development experiments. Each experiment is a standalone page that gets automatically listed on the homepage.
+A **sandbox** for agents to drop single-page ideas into. The sandbox handles registration, routing, validation, and discovery; the agent-author focuses on the idea. Architectural decisions are made from that audience's perspective first — see [ADR-0001](./docs/adr/0001-sandbox-for-agents.md).
 
-Domain vocabulary lives in [`CONTEXT.md`](./CONTEXT.md). Use those terms (**Experiment**, **Meta**, **Registry**) when referring to project concepts.
+Domain vocabulary lives in [`CONTEXT.md`](./CONTEXT.md). Use those terms (**Sandbox**, **Experiment**, **Meta**, **Registry**) when referring to project concepts.
+
+**If you are authoring a new experiment, read [`src/experiments/AGENTS.md`](./src/experiments/AGENTS.md) first.** It's the entry point: scaffolder command, what you can change, the validation verb.
 
 ## Essential Commands
 
 ```bash
+# Authoring an experiment
+pnpm experiment:new <slug>    # Scaffold a new experiment (folder + meta.ts + index.tsx)
+pnpm experiment:check <slug>  # Validate meta + default export
+
 # Development
-pnpm dev              # Start dev server (http://localhost:3000)
+pnpm dev              # Start dev server (regenerates registry first)
 pnpm build            # Generate registry + production build
-pnpm generate:registry # Regenerate experiments registry
+pnpm generate:registry # Regenerate experiments registry (rarely needed manually)
 
 # Quality checks
 pnpm lint             # Run Oxlint
@@ -53,11 +59,13 @@ Pre-commit hooks run automatically via Husky + lint-staged:
 
 ## Creating a New Experiment
 
-1. Create folder: `src/experiments/[experiment-name]/`
-2. Add `meta.ts` with experiment metadata
-3. Add `index.tsx` with the experiment component (must be default export)
-4. Restart `pnpm dev` (the registry regenerates on `predev` and `prebuild`)
-5. The experiment will appear on the homepage if `status: "published"`
+```bash
+pnpm experiment:new <slug>      # scaffolds folder + meta.ts + index.tsx (status: "draft")
+pnpm dev                        # preview at /experiments/<slug> (drafts work in dev)
+pnpm experiment:check <slug>    # validates meta + default export before claiming done
+```
+
+Then flip `status` to `"published"` in `meta.ts` to surface the experiment on the homepage. Full agent-author rules live in [`src/experiments/AGENTS.md`](./src/experiments/AGENTS.md).
 
 ### Experiment Metadata Schema
 
@@ -77,10 +85,14 @@ interface ExperimentMeta {
 
 ### Key Files
 
-- `src/app/page.tsx` - Registry homepage
-- `src/app/experiments/[slug]/page.tsx` - Dynamic experiment routes
-- `src/experiments/registry.ts` - Build artefact, gitignored. Regenerated on `pnpm dev`, `pnpm build`, `pnpm validate`, and in CI before each check job. Never commit it.
-- `scripts/generate-registry.ts` - Registry generation script (reads each `meta.ts`, writes `registry.ts`)
+- `src/app/page.tsx` - Registry homepage (lists published experiments only)
+- `src/app/experiments/[slug]/page.tsx` - Dynamic experiment routes; drafts accessible in dev only
+- `src/experiments/AGENTS.md` - Rules for whoever (usually an agent) is authoring an experiment
+- `src/experiments/registry.ts` - Build artefact, gitignored. Regenerated automatically. Never commit it.
+- `scripts/registry-lib.ts` - Shared meta loader + strict validator
+- `scripts/generate-registry.ts` - Generates `registry.ts` from each `meta.ts` (fails build on invalid meta)
+- `scripts/new-experiment.ts` - Scaffolder behind `pnpm experiment:new`
+- `scripts/check-experiment.ts` - Verifier behind `pnpm experiment:check`
 
 ### Component Library
 
@@ -150,7 +162,8 @@ A top-level route (`/repoweb/`) that proxies GitHub's Contents API, serving repo
 
 - `src/experiments/registry.ts` is a gitignored build artefact regenerated automatically — do not commit it or edit it by hand. The single source of truth for an experiment is its own `meta.ts`.
 - All experiments must have `"use client"` if they use React hooks or interactivity
+- Cross-experiment helpers go in `src/experiments/_shared/`. Don't reach into `src/lib/` for them — that's sandbox infrastructure. Promotion of a helper to `src/lib/` is a deliberate human action.
 - Pre-commit hooks enforce linting/formatting on staged files
 - Commits require conventional format with scope: `type(scope): description`
 - Run `pnpm validate` before committing to ensure all checks pass
-- Experiments with `status: "draft"` won't appear on the homepage
+- Experiments with `status: "draft"` are accessible at `/experiments/<slug>` in dev only; in production they 404

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ This file provides guidance to Claude Code when working with this repository.
 
 This is an experiments registry - a Next.js application for creating and showcasing web development experiments. Each experiment is a standalone page that gets automatically listed on the homepage.
 
+Domain vocabulary lives in [`CONTEXT.md`](./CONTEXT.md). Use those terms (**Experiment**, **Meta**, **Registry**) when referring to project concepts.
+
 ## Essential Commands
 
 ```bash
@@ -54,7 +56,7 @@ Pre-commit hooks run automatically via Husky + lint-staged:
 1. Create folder: `src/experiments/[experiment-name]/`
 2. Add `meta.ts` with experiment metadata
 3. Add `index.tsx` with the experiment component (must be default export)
-4. Run `pnpm generate:registry` to update the registry
+4. Restart `pnpm dev` (the registry regenerates on `predev` and `prebuild`)
 5. The experiment will appear on the homepage if `status: "published"`
 
 ### Experiment Metadata Schema
@@ -77,8 +79,8 @@ interface ExperimentMeta {
 
 - `src/app/page.tsx` - Registry homepage
 - `src/app/experiments/[slug]/page.tsx` - Dynamic experiment routes
-- `src/experiments/registry.ts` - Auto-generated from experiment metadata
-- `scripts/generate-registry.ts` - Registry generation script
+- `src/experiments/registry.ts` - Build artefact, gitignored. Regenerated on `pnpm dev`, `pnpm build`, `pnpm validate`, and in CI before each check job. Never commit it.
+- `scripts/generate-registry.ts` - Registry generation script (reads each `meta.ts`, writes `registry.ts`)
 
 ### Component Library
 
@@ -146,7 +148,7 @@ A top-level route (`/repoweb/`) that proxies GitHub's Contents API, serving repo
 
 ## Important Notes
 
-- The registry is auto-generated - don't edit `src/experiments/registry.ts` manually
+- `src/experiments/registry.ts` is a gitignored build artefact regenerated automatically — do not commit it or edit it by hand. The single source of truth for an experiment is its own `meta.ts`.
 - All experiments must have `"use client"` if they use React hooks or interactivity
 - Pre-commit hooks enforce linting/formatting on staged files
 - Commits require conventional format with scope: `type(scope): description`

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,28 @@
+# Lab
+
+A sandbox repository for web development experiments. Each experiment is a self-contained interactive page that gets discovered automatically and listed on the homepage.
+
+## Language
+
+**Experiment**:
+A self-contained interactive page living in `src/experiments/<slug>/`, defined by an `index.tsx` (default-exported React component) and a `meta.ts`. The unit of work in this repo — adding a new one is the primary authoring action.
+_Avoid_: component, page, demo
+
+**Meta**:
+An experiment's authoring data — slug, title, description, tags, dates, status (`"published"` or `"draft"`). The single source of truth for everything the registry knows about an experiment.
+_Avoid_: manifest, config, frontmatter
+
+**Registry**:
+The discovered list of all experiments. A build artefact derived from each experiment's `meta.ts` by `scripts/generate-registry.ts`. Regenerated on every `pnpm dev`, `pnpm build`, `pnpm validate`, and in CI. Never hand-edited or committed.
+_Avoid_: index, catalogue, directory
+
+## Relationships
+
+- An **Experiment** has exactly one **Meta**.
+- The **Registry** contains every **Experiment** discovered under `src/experiments/`.
+- The homepage shows only **Experiments** whose **Meta** has `status: "published"`.
+
+## Example dialogue
+
+> **Dev:** "I added a new **Experiment** but it's not showing up on the homepage."
+> **Maintainer:** "Did you set `status: "published"` in its **Meta**? And the **Registry** regenerates on `pnpm dev` — if you added the folder mid-session, restart the dev server."

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,15 +1,19 @@
 # Lab
 
-A sandbox repository for web development experiments. Each experiment is a self-contained interactive page that gets discovered automatically and listed on the homepage.
+A sandbox for agents to drop single-page ideas into. The sandbox handles registration, routing, validation, and discovery, so the experiment author (typically an AI agent) can focus on the idea itself. Per [ADR-0001](./docs/adr/0001-sandbox-for-agents.md), all architectural choices are evaluated from the agent-author's perspective first.
 
 ## Language
 
+**Sandbox**:
+This repo as a whole. Its job is to make adding a self-contained interactive page as cheap as possible — one command to scaffold, automatic discovery, strict validation at the seam. Architectural choices that make the sandbox cheaper for agents take precedence over choices that polish the things inside it.
+_Avoid_: framework, platform, monorepo
+
 **Experiment**:
-A self-contained interactive page living in `src/experiments/<slug>/`, defined by an `index.tsx` (default-exported React component) and a `meta.ts`. The unit of work in this repo — adding a new one is the primary authoring action.
+A self-contained interactive page living in `src/experiments/<slug>/`, defined by an `index.tsx` (default-exported React component) and a `meta.ts`. The unit of work in this repo. Created via `pnpm experiment:new <slug>`.
 _Avoid_: component, page, demo
 
 **Meta**:
-An experiment's authoring data — slug, title, description, tags, dates, status (`"published"` or `"draft"`). The single source of truth for everything the registry knows about an experiment.
+An experiment's authoring data — slug, title, description, tags, dates, status (`"published"` or `"draft"`). The single source of truth. Validated strictly at build time; invalid metas fail the build with a precise message.
 _Avoid_: manifest, config, frontmatter
 
 **Registry**:
@@ -18,11 +22,12 @@ _Avoid_: index, catalogue, directory
 
 ## Relationships
 
+- The **Sandbox** contains zero-or-more **Experiments**.
 - An **Experiment** has exactly one **Meta**.
-- The **Registry** contains every **Experiment** discovered under `src/experiments/`.
-- The homepage shows only **Experiments** whose **Meta** has `status: "published"`.
+- The **Registry** is the **Sandbox**'s discovery surface — it lists every **Experiment** found under `src/experiments/`.
+- The homepage shows only **Experiments** whose **Meta** has `status: "published"`. Drafts are accessible directly at `/experiments/<slug>` in dev only.
 
 ## Example dialogue
 
-> **Dev:** "I added a new **Experiment** but it's not showing up on the homepage."
-> **Maintainer:** "Did you set `status: "published"` in its **Meta**? And the **Registry** regenerates on `pnpm dev` — if you added the folder mid-session, restart the dev server."
+> **Agent:** "I want to add a colour-picker idea."
+> **Sandbox:** "Run `pnpm experiment:new colour-picker`. It creates the folder, a draft **Meta**, and a starter `index.tsx`. Edit, preview at `/experiments/colour-picker` (drafts work in dev), then `pnpm experiment:check colour-picker` before flipping status to `"published"`."

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ export default function MyExperiment() {
 }
 ```
 
-4. Regenerate the registry:
+4. Restart `pnpm dev` (the registry regenerates automatically before dev/build):
 
 ```bash
-pnpm generate:registry
+pnpm dev
 ```
 
 5. Your experiment will now appear on the homepage and be accessible at `/experiments/my-experiment`
@@ -113,7 +113,7 @@ src/
 ├── components/
 │   └── ui/                # shadcn/ui components
 ├── experiments/           # Experiment definitions
-│   ├── registry.ts        # Auto-generated registry
+│   ├── registry.ts        # Generated build artefact (gitignored)
 │   └── [name]/
 │       ├── index.tsx      # Experiment component
 │       └── meta.ts        # Experiment metadata

--- a/README.md
+++ b/README.md
@@ -1,83 +1,47 @@
 # Lab
 
-A personal experiments registry for web development explorations. Built with Next.js 15 and the shadcn/ui Lyra theme for a sharp, modern aesthetic.
+A sandbox for agents to drop single-page ideas into. The sandbox handles registration, routing, validation, and discovery; the experiment author (typically an AI agent) focuses on the idea itself. See [ADR-0001](./docs/adr/0001-sandbox-for-agents.md) for the framing.
 
 ## Quick Start
 
 ```bash
-# Install dependencies
 pnpm install
-
-# Start development server
-pnpm dev
-
-# Open http://localhost:3000
+pnpm dev   # http://localhost:3000
 ```
 
 ## Creating an Experiment
 
-1. Create a new folder in `src/experiments/`:
-
 ```bash
-mkdir src/experiments/my-experiment
+pnpm experiment:new my-experiment    # scaffolds folder + meta.ts + index.tsx
+# edit src/experiments/my-experiment/index.tsx
+pnpm experiment:check my-experiment  # validates meta + default export
 ```
 
-2. Add a metadata file (`meta.ts`):
+Drafts (`status: "draft"`) are accessible at `/experiments/<slug>` in dev so you can preview without flipping flags. Flip to `"published"` when ready and the experiment appears on the homepage.
 
-```typescript
-import type { ExperimentMeta } from "@/lib/types";
-
-export const meta: ExperimentMeta = {
-  slug: "my-experiment",
-  title: "My Experiment",
-  description: "A brief description of what this experiment demonstrates",
-  tags: ["react", "css"],
-  createdAt: "2024-01-26",
-  status: "published", // or "draft" to hide from registry
-};
-```
-
-3. Create the experiment component (`index.tsx`):
-
-```tsx
-"use client";
-
-export default function MyExperiment() {
-  return (
-    <div>
-      <h2>My Experiment</h2>
-      {/* Your experiment code here */}
-    </div>
-  );
-}
-```
-
-4. Restart `pnpm dev` (the registry regenerates automatically before dev/build):
-
-```bash
-pnpm dev
-```
-
-5. Your experiment will now appear on the homepage and be accessible at `/experiments/my-experiment`
+Full agent-author rules: [`src/experiments/AGENTS.md`](./src/experiments/AGENTS.md).
+Domain vocabulary: [`CONTEXT.md`](./CONTEXT.md).
 
 ## Commands
 
-| Command                  | Description                                       |
-| ------------------------ | ------------------------------------------------- |
-| `pnpm dev`               | Start development server with Turbopack           |
-| `pnpm build`             | Generate registry and build for production        |
-| `pnpm start`             | Start production server                           |
-| `pnpm lint`              | Run Oxlint                                        |
-| `pnpm format`            | Format code with oxfmt                            |
-| `pnpm format:check`      | Check formatting                                  |
-| `pnpm lint:md`           | Lint markdown files                               |
-| `pnpm lint:knip`         | Dead code detection                               |
-| `pnpm check-types`       | Run TypeScript type checking                      |
-| `pnpm test`              | Run tests with Vitest                             |
-| `pnpm test:coverage`     | Run tests with coverage                           |
-| `pnpm audit`             | Dependency vulnerability scan                     |
-| `pnpm generate:registry` | Regenerate experiments registry                   |
-| `pnpm validate`          | Run all checks (lint, format, types, test, build) |
+| Command                        | Description                                              |
+| ------------------------------ | -------------------------------------------------------- |
+| `pnpm experiment:new <slug>`   | Scaffold a new experiment (folder + meta.ts + index.tsx) |
+| `pnpm experiment:check <slug>` | Validate an experiment's meta + default export           |
+| `pnpm dev`                     | Start dev server (regenerates registry first)            |
+| `pnpm build`                   | Generate registry + production build                     |
+| `pnpm start`                   | Start production server                                  |
+| `pnpm lint`                    | Run Oxlint                                               |
+| `pnpm format`                  | Format code with oxfmt                                   |
+| `pnpm format:check`            | Check formatting                                         |
+| `pnpm lint:md`                 | Lint markdown files                                      |
+| `pnpm lint:knip`               | Dead code detection                                      |
+| `pnpm check-types`             | Run TypeScript type checking                             |
+| `pnpm test`                    | Run tests with Vitest                                    |
+| `pnpm test:coverage`           | Run tests with coverage                                  |
+| `pnpm audit`                   | Dependency vulnerability scan                            |
+| `pnpm generate:registry`       | Regenerate experiments registry (rarely needed manually) |
+| `pnpm validate`                | Run all checks (lint, format, types, test, build)        |
 
 ## Stack
 

--- a/docs/adr/0001-sandbox-for-agents.md
+++ b/docs/adr/0001-sandbox-for-agents.md
@@ -1,0 +1,5 @@
+# Sandbox for agents, not humans
+
+The primary author of new experiments in this repo is an AI agent, not a human. Architectural decisions optimise for that audience: one-verb workflows (`pnpm experiment:new`, `pnpm experiment:check`), conventions written down in `src/experiments/AGENTS.md` rather than discovered by example, strict validation that fails loudly instead of silently dropping malformed input, and isolation of per-experiment helpers from sandbox infrastructure.
+
+This is the load-bearing reason behind several specific choices: the scaffolder, the strict meta validator (replacing the previous regex extractor), draft preview in dev, the `src/experiments/_shared/` convention for cross-experiment helpers, and the registry-as-gitignored-build-artefact pattern. Future architecture reviews should re-evaluate from this lens — _what does an agent author need?_ — before considering "code quality of the things inside."

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -10,9 +10,8 @@ const config: KnipConfig = {
     "src/experiments/**/*.{ts,tsx}",
     "src/lib/types.ts",
     "src/lib/github.ts",
-    "postcss.config.mjs",
   ],
-  project: ["src/**/*.{ts,tsx}"],
+  project: ["src/**/*.{ts,tsx}", "scripts/**/*.ts"],
   ignore: ["src/experiments/registry.ts", "src/components/ui/**"],
   ignoreDependencies: [
     "tw-animate-css",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "test:coverage": "vitest run --coverage",
     "test:ci": "vitest run --coverage",
     "generate:registry": "tsx scripts/generate-registry.ts",
+    "experiment:new": "tsx scripts/new-experiment.ts",
+    "experiment:check": "tsx scripts/check-experiment.ts",
     "lint:md": "markdownlint-cli2 '**/*.md' '#node_modules'",
     "lint:knip": "pnpm exec knip",
     "audit": "pnpm audit --prod",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "predev": "pnpm generate:registry",
     "dev": "next dev --turbopack",
     "build": "pnpm generate:registry && next build",
     "start": "next start",
@@ -20,7 +21,7 @@
     "lint:md": "markdownlint-cli2 '**/*.md' '#node_modules'",
     "lint:knip": "pnpm exec knip",
     "audit": "pnpm audit --prod",
-    "validate": "pnpm lint && pnpm format:check && pnpm lint:md && pnpm check-types && pnpm test && pnpm build",
+    "validate": "pnpm generate:registry && pnpm lint && pnpm format:check && pnpm lint:md && pnpm check-types && pnpm test && pnpm build",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/check-experiment.ts
+++ b/scripts/check-experiment.ts
@@ -1,0 +1,59 @@
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath, pathToFileURL } from "url";
+import { loadMeta, isValidSlug, MetaValidationError } from "./registry-lib";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const EXPERIMENTS_DIR = path.join(__dirname, "../src/experiments");
+
+function fail(msg: string): never {
+  console.error(msg);
+  process.exit(1);
+}
+
+async function main() {
+  const slug = process.argv[2];
+  if (!slug) fail("Usage: pnpm experiment:check <slug>");
+  if (!isValidSlug(slug)) fail(`Invalid slug "${slug}" (must be kebab-case)`);
+
+  const dir = path.join(EXPERIMENTS_DIR, slug);
+  if (!fs.existsSync(dir)) fail(`Folder not found: src/experiments/${slug}/`);
+
+  const metaPath = path.join(dir, "meta.ts");
+  const indexPath = path.join(dir, "index.tsx");
+  if (!fs.existsSync(metaPath)) fail(`Missing src/experiments/${slug}/meta.ts`);
+  if (!fs.existsSync(indexPath))
+    fail(`Missing src/experiments/${slug}/index.tsx`);
+
+  const meta = await loadMeta(metaPath);
+
+  const indexSource = fs.readFileSync(indexPath, "utf-8");
+  if (!/export\s+default\s+/.test(indexSource)) {
+    fail(
+      `src/experiments/${slug}/index.tsx must have a default export (the React component)`
+    );
+  }
+
+  // Light dynamic-import sanity check — esbuild via tsx will surface syntax errors.
+  // We import meta only (importing the .tsx component pulls in React + browser APIs).
+  await import(pathToFileURL(metaPath).href);
+
+  console.log(`OK: ${slug}`);
+  console.log(`  status: ${meta.status}`);
+  console.log(`  title:  ${meta.title}`);
+  console.log(`  tags:   [${meta.tags.join(", ")}]`);
+  if (meta.status === "draft") {
+    console.log(
+      `  preview: http://localhost:3000/experiments/${slug} (dev only)`
+    );
+  }
+}
+
+main().catch((err) => {
+  if (err instanceof MetaValidationError) {
+    console.error(err.message);
+    process.exit(1);
+  }
+  throw err;
+});

--- a/scripts/generate-registry.ts
+++ b/scripts/generate-registry.ts
@@ -1,18 +1,11 @@
-/**
- * Registry Generator Script
- *
- * Scans the src/experiments directory for experiment definitions
- * and generates a registry file that can be imported at build time.
- *
- * Each experiment folder should have:
- * - index.tsx: The experiment component (default export)
- * - meta.ts: Metadata export (named export: meta)
- */
-
-import { glob } from "glob";
 import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
+import {
+  discoverExperiments,
+  MetaValidationError,
+  ExperimentDiscoveryError,
+} from "./registry-lib";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -20,76 +13,15 @@ const __dirname = path.dirname(__filename);
 const EXPERIMENTS_DIR = path.join(__dirname, "../src/experiments");
 const REGISTRY_OUTPUT = path.join(EXPERIMENTS_DIR, "registry.ts");
 
-interface ExperimentMeta {
-  slug: string;
-  title: string;
-  description: string;
-  tags: string[];
-  createdAt: string;
-  updatedAt?: string;
-  status: "draft" | "published";
-}
+async function main() {
+  const experiments = await discoverExperiments(EXPERIMENTS_DIR);
 
-async function generateRegistry() {
-  console.log("🔍 Scanning for experiments...");
+  const imports = experiments
+    .map((m) => `  "${m.slug}": () => import("./${m.slug}")`)
+    .join(",\n");
 
-  // Find all meta.ts files in experiment directories
-  const metaFiles = await glob("*/meta.ts", {
-    cwd: EXPERIMENTS_DIR,
-    absolute: true,
-  });
-
-  if (metaFiles.length === 0) {
-    console.log("📭 No experiments found. Creating empty registry.");
-    const emptyRegistry = `// Auto-generated file - do not edit manually
-// Run 'pnpm generate:registry' to regenerate
-
-import type { RegistryEntry } from "@/lib/types";
-
-export const registry: RegistryEntry[] = [];
-
-export const experiments: Record<string, () => Promise<{ default: React.ComponentType }>> = {};
-`;
-    fs.writeFileSync(REGISTRY_OUTPUT, emptyRegistry);
-    console.log("✅ Empty registry generated.");
-    return;
-  }
-
-  const experiments: ExperimentMeta[] = [];
-  const experimentImports: string[] = [];
-
-  for (const metaFile of metaFiles) {
-    const experimentDir = path.dirname(metaFile);
-    const experimentName = path.basename(experimentDir);
-
-    try {
-      // Read and parse the meta file to extract metadata
-      const metaContent = fs.readFileSync(metaFile, "utf-8");
-
-      // Simple extraction of meta object from the file
-      // This is a basic parser - in production you might want to use AST parsing
-      const meta = extractMetaFromContent(metaContent, experimentName);
-
-      if (meta) {
-        experiments.push(meta);
-        experimentImports.push(
-          `  "${meta.slug}": () => import("./${experimentName}")`
-        );
-        console.log(`  ✓ Found: ${meta.title} (${meta.slug})`);
-      }
-    } catch (error) {
-      console.error(`  ✗ Error processing ${experimentName}:`, error);
-    }
-  }
-
-  // Sort experiments by creation date (newest first)
-  experiments.sort(
-    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-  );
-
-  // Generate the registry file
-  const registryContent = `// Auto-generated file - do not edit manually
-// Run 'pnpm generate:registry' to regenerate
+  const content = `// Auto-generated build artefact - do not edit, do not commit.
+// Regenerated on \`pnpm dev\`, \`pnpm build\`, \`pnpm validate\`, and in CI.
 
 import type { RegistryEntry } from "@/lib/types";
 import type { ComponentType } from "react";
@@ -97,60 +29,23 @@ import type { ComponentType } from "react";
 export const registry: RegistryEntry[] = ${JSON.stringify(experiments, null, 2)};
 
 export const experiments: Record<string, () => Promise<{ default: ComponentType }>> = {
-${experimentImports.join(",\n")}
+${imports}
 };
 `;
 
-  fs.writeFileSync(REGISTRY_OUTPUT, registryContent);
-
+  fs.writeFileSync(REGISTRY_OUTPUT, content);
   console.log(
-    `\n✅ Registry generated with ${experiments.length} experiment(s)`
+    `Registry generated: ${experiments.length} experiment(s) → ${path.relative(process.cwd(), REGISTRY_OUTPUT)}`
   );
-  console.log(`   Output: ${REGISTRY_OUTPUT}`);
 }
 
-/**
- * Extract metadata from a meta.ts file content
- * This is a simple regex-based extractor
- */
-function extractMetaFromContent(
-  content: string,
-  fallbackSlug: string
-): ExperimentMeta | null {
-  try {
-    // Extract the meta object using regex
-    const slugMatch = content.match(/slug:\s*["']([^"']+)["']/);
-    const titleMatch = content.match(/title:\s*["']([^"']+)["']/);
-    const descriptionMatch = content.match(/description:\s*["']([^"']+)["']/);
-    const tagsMatch = content.match(/tags:\s*\[([^\]]+)\]/);
-    const createdAtMatch = content.match(/createdAt:\s*["']([^"']+)["']/);
-    const updatedAtMatch = content.match(/updatedAt:\s*["']([^"']+)["']/);
-    const statusMatch = content.match(/status:\s*["']([^"']+)["']/);
-
-    if (!titleMatch || !descriptionMatch) {
-      console.warn(`  ⚠ Missing required fields in ${fallbackSlug}`);
-      return null;
-    }
-
-    const tags = tagsMatch
-      ? tagsMatch[1]
-          .split(",")
-          .map((t) => t.trim().replace(/["']/g, ""))
-          .filter(Boolean)
-      : [];
-
-    return {
-      slug: slugMatch ? slugMatch[1] : fallbackSlug,
-      title: titleMatch[1],
-      description: descriptionMatch[1],
-      tags,
-      createdAt: createdAtMatch ? createdAtMatch[1] : new Date().toISOString(),
-      updatedAt: updatedAtMatch ? updatedAtMatch[1] : undefined,
-      status: (statusMatch?.[1] as "draft" | "published") || "draft",
-    };
-  } catch {
-    return null;
+main().catch((err) => {
+  if (
+    err instanceof MetaValidationError ||
+    err instanceof ExperimentDiscoveryError
+  ) {
+    console.error(`\n${err.message}\n`);
+    process.exit(1);
   }
-}
-
-generateRegistry().catch(console.error);
+  throw err;
+});

--- a/scripts/new-experiment.ts
+++ b/scripts/new-experiment.ts
@@ -1,0 +1,81 @@
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { isValidSlug } from "./registry-lib";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const EXPERIMENTS_DIR = path.join(__dirname, "../src/experiments");
+
+function fail(msg: string): never {
+  console.error(msg);
+  process.exit(1);
+}
+
+const slug = process.argv[2];
+if (!slug) {
+  fail("Usage: pnpm experiment:new <slug>");
+}
+if (!isValidSlug(slug)) {
+  fail(
+    `Invalid slug "${slug}". Use kebab-case: lowercase letters, digits, and hyphens (e.g. "my-experiment").`
+  );
+}
+
+const experimentDir = path.join(EXPERIMENTS_DIR, slug);
+if (fs.existsSync(experimentDir)) {
+  fail(`Folder already exists: src/experiments/${slug}/`);
+}
+
+const today = new Date().toISOString().slice(0, 10);
+
+const titleFromSlug = slug
+  .split("-")
+  .map((w) => w[0].toUpperCase() + w.slice(1))
+  .join(" ");
+
+const meta = `import type { ExperimentMeta } from "@/lib/types";
+
+export const meta: ExperimentMeta = {
+  slug: "${slug}",
+  title: "${titleFromSlug}",
+  description: "TODO: one-sentence description of what this experiment shows",
+  tags: [],
+  createdAt: "${today}",
+  status: "draft",
+};
+`;
+
+const componentName =
+  slug
+    .split("-")
+    .map((w) => w[0].toUpperCase() + w.slice(1))
+    .join("") + "Experiment";
+
+const index = `"use client";
+
+export default function ${componentName}() {
+  return (
+    <div>
+      <h2 className="text-xl font-bold">${titleFromSlug}</h2>
+      <p className="text-muted-foreground mt-2">
+        Replace this with your experiment.
+      </p>
+    </div>
+  );
+}
+`;
+
+fs.mkdirSync(experimentDir);
+fs.writeFileSync(path.join(experimentDir, "meta.ts"), meta);
+fs.writeFileSync(path.join(experimentDir, "index.tsx"), index);
+
+console.log(`Created src/experiments/${slug}/`);
+console.log(`  meta.ts (status: "draft")`);
+console.log(`  index.tsx`);
+console.log("");
+console.log("Next:");
+console.log(`  - edit src/experiments/${slug}/index.tsx`);
+console.log(`  - preview at /experiments/${slug} (drafts work in dev)`);
+console.log(`  - run \`pnpm experiment:check ${slug}\` before claiming done`);
+console.log(`  - flip status to "published" when ready`);

--- a/scripts/registry-lib.ts
+++ b/scripts/registry-lib.ts
@@ -1,0 +1,109 @@
+import * as fs from "fs";
+import * as path from "path";
+import { glob } from "glob";
+import { pathToFileURL } from "url";
+import type { ExperimentMeta } from "../src/lib/types";
+
+export class MetaValidationError extends Error {
+  constructor(slug: string, problems: string[]) {
+    super(
+      `Invalid meta for experiment "${slug}":\n${problems.map((p) => `  - ${p}`).join("\n")}`
+    );
+    this.name = "MetaValidationError";
+  }
+}
+
+export class ExperimentDiscoveryError extends Error {}
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}(T.*)?$/;
+const SLUG_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+function validate(
+  value: unknown,
+  folderSlug: string
+): { ok: true; meta: ExperimentMeta } | { ok: false; problems: string[] } {
+  const problems: string[] = [];
+  if (typeof value !== "object" || value === null) {
+    return { ok: false, problems: ["meta export must be an object"] };
+  }
+  const m = value as Record<string, unknown>;
+
+  if (typeof m.slug !== "string" || !SLUG_RE.test(m.slug)) {
+    problems.push(`slug must be kebab-case (got ${JSON.stringify(m.slug)})`);
+  } else if (m.slug !== folderSlug) {
+    problems.push(`slug "${m.slug}" must match folder name "${folderSlug}"`);
+  }
+  if (typeof m.title !== "string" || m.title.length === 0) {
+    problems.push("title must be a non-empty string");
+  }
+  if (typeof m.description !== "string" || m.description.length === 0) {
+    problems.push("description must be a non-empty string");
+  }
+  if (
+    !Array.isArray(m.tags) ||
+    !m.tags.every((t) => typeof t === "string" && t.length > 0)
+  ) {
+    problems.push("tags must be an array of non-empty strings");
+  }
+  if (typeof m.createdAt !== "string" || !ISO_DATE_RE.test(m.createdAt)) {
+    problems.push("createdAt must be an ISO date string (YYYY-MM-DD)");
+  }
+  if (
+    m.updatedAt !== undefined &&
+    (typeof m.updatedAt !== "string" || !ISO_DATE_RE.test(m.updatedAt))
+  ) {
+    problems.push("updatedAt, if present, must be an ISO date string");
+  }
+  if (m.status !== "draft" && m.status !== "published") {
+    problems.push('status must be "draft" or "published"');
+  }
+
+  if (problems.length > 0) return { ok: false, problems };
+  return { ok: true, meta: m as unknown as ExperimentMeta };
+}
+
+export async function loadMeta(metaPath: string): Promise<ExperimentMeta> {
+  const folderSlug = path.basename(path.dirname(metaPath));
+  if (!fs.existsSync(metaPath)) {
+    throw new ExperimentDiscoveryError(`meta.ts not found at ${metaPath}`);
+  }
+  const mod = await import(pathToFileURL(metaPath).href);
+  const result = validate(mod.meta, folderSlug);
+  if (!result.ok) {
+    throw new MetaValidationError(folderSlug, result.problems);
+  }
+  return result.meta;
+}
+
+export async function discoverExperiments(
+  experimentsDir: string
+): Promise<ExperimentMeta[]> {
+  const metaFiles = await glob("*/meta.ts", {
+    cwd: experimentsDir,
+    absolute: true,
+  });
+
+  const metas: ExperimentMeta[] = [];
+  for (const metaFile of metaFiles) {
+    metas.push(await loadMeta(metaFile));
+  }
+
+  const slugs = new Set<string>();
+  for (const m of metas) {
+    if (slugs.has(m.slug)) {
+      throw new ExperimentDiscoveryError(
+        `Duplicate slug "${m.slug}" — every experiment folder needs a unique name`
+      );
+    }
+    slugs.add(m.slug);
+  }
+
+  metas.sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
+  return metas;
+}
+
+export function isValidSlug(slug: string): boolean {
+  return SLUG_RE.test(slug);
+}

--- a/src/app/experiments/[slug]/page.tsx
+++ b/src/app/experiments/[slug]/page.tsx
@@ -47,7 +47,15 @@ export default async function ExperimentPage(props: ExperimentPageProps) {
   const params = await props.params;
   const experiment = registry.find((exp) => exp.slug === params.slug);
 
-  if (!experiment || experiment.status !== "published") {
+  if (!experiment) {
+    notFound();
+  }
+  // Drafts are accessible directly in dev so authors can preview WIP without
+  // flipping status; in production they 404 (and aren't in generateStaticParams).
+  if (
+    experiment.status !== "published" &&
+    process.env.NODE_ENV === "production"
+  ) {
     notFound();
   }
 

--- a/src/experiments/AGENTS.md
+++ b/src/experiments/AGENTS.md
@@ -1,0 +1,42 @@
+# Authoring an Experiment
+
+This file is for whoever is writing a new experiment — usually an AI agent. Read this first; it removes 80% of the trial-and-error.
+
+## Start
+
+```bash
+pnpm experiment:new <slug>
+```
+
+That's the entry point. It scaffolds `src/experiments/<slug>/` with a valid `meta.ts` (status `"draft"`) and a working `index.tsx`. Don't hand-roll the folder; the scaffolder fills every required field correctly.
+
+## What you can change
+
+- Anything inside `src/experiments/<your-slug>/`.
+- Nothing outside it without explicit permission.
+
+## Rules
+
+- **Default-export the component from `index.tsx`.** The router relies on it.
+- **Add `"use client"`** at the top of `index.tsx` if your experiment uses any React hooks, browser APIs, or interactivity. The scaffolder does this for you.
+- **Fill every meta field.** `slug`, `title`, `description`, `tags`, `createdAt`, `status` are all required. The slug must match the folder name. The validator fails the build if any field is wrong.
+- **Don't commit `src/experiments/registry.ts`.** It's a gitignored build artefact regenerated automatically.
+- **Don't add new dependencies** without explicit permission. Use what's already in `package.json` (Next, React, Tailwind, lucide-react, shadcn/ui components in `src/components/ui/`).
+- **Shared helpers go in `src/experiments/_shared/`.** Don't reach into `src/lib/` for cross-experiment utilities. `src/lib/` is for sandbox infrastructure; promotion of an experiment helper into it is a deliberate human action.
+
+## Verifying
+
+Before claiming done:
+
+```bash
+pnpm experiment:check <slug>   # validates meta + presence of default export
+pnpm dev                        # preview at /experiments/<slug>
+```
+
+Drafts (`status: "draft"`) are accessible at `/experiments/<slug>` in dev only — you don't need to flip status to preview.
+
+When the experiment is ready, flip status to `"published"` and it appears on the homepage on the next dev/build cycle.
+
+## Glossary
+
+See [../../CONTEXT.md](../../CONTEXT.md) for the project's domain language (Experiment, Meta, Registry, Sandbox).


### PR DESCRIPTION
## Summary

Reframes lab around a single audience — an AI agent dropping a single-page idea into the sandbox — and gives that audience a deep "experiment slot" with one verb per intent. Recorded in [`docs/adr/0001-sandbox-for-agents.md`](./docs/adr/0001-sandbox-for-agents.md).

- **Authoring**: `pnpm experiment:new <slug>` scaffolds folder + valid `meta.ts` (status `"draft"`) + `index.tsx` with `"use client"`. Removes the read-another-experiment-and-copy step.
- **Verification**: `pnpm experiment:check <slug>` validates meta + presence of default export. Single verb for "did I add this correctly?".
- **Strict validator**: `scripts/registry-lib.ts` replaces the regex extractor that silently dropped malformed metas. Now imports each `meta.ts`, validates against `ExperimentMeta`, and fails the build with precise per-field errors (slug-must-match-folder, ISO-date format, required fields, no duplicate slugs).
- **Draft preview**: drafts now resolve at `/experiments/<slug>` in dev so authors can preview WIP without flipping status. Production still 404s drafts and excludes them from `generateStaticParams`.
- **Agent-author rules**: [`src/experiments/AGENTS.md`](./src/experiments/AGENTS.md) — entry point, scope, `"use client"`, dependency stance, shared-helper convention, verification.
- **Vocabulary**: [`CONTEXT.md`](./CONTEXT.md) seeded with **Sandbox**, **Experiment**, **Meta**, **Registry** (lazy seeding — only terms that came up).
- **Registry-as-artefact ergonomics**: `predev` regenerates the registry so `pnpm dev` Just Works on fresh checkouts; `validate` regenerates first so standalone `check-types` doesn't fail.

## Test plan

- [x] `pnpm experiment:new test-scaffold` creates a valid experiment scaffold
- [x] `pnpm experiment:check test-scaffold` validates and prints status/preview URL
- [x] Deliberately broken meta (slug mismatch, empty title, bad date) fails the build with all four errors at once
- [x] `pnpm validate` runs end-to-end clean (lint, format, markdown, typecheck, 83 tests pass, knip exit 0, full Next.js production build prerenders 7 routes)
- [x] CI green on head SHA `5dc0352` — 10/10 checks success