### PR TITLE
docs(readme): correct RepoWeb hostname from .com to .dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ src/
 A built-in GitHub repository proxy for AI agents. Browse any public repo as plain text:
 
 ```text
-lab.joshmu.com/repoweb/owner/repo/path
+lab.joshmu.dev/repoweb/owner/repo/path
 ```
 
 All responses are `text/plain` — no rendering, just raw content optimized for AI consumption. See [docs/repoweb.md](docs/repoweb.md) for full documentation.


### PR DESCRIPTION
## Summary

- `README.md` advertises the RepoWeb endpoint as `lab.joshmu.com/...`, but that host has no DNS record (`curl: (6) Could not resolve host: lab.joshmu.com`).
- `docs/repoweb.md` already documents the correct host (`lab.joshmu.dev`), so the README was the sole outlier.
- One-line fix to align the README example with the actual deployment.

## Test plan

- [x] Verified `lab.joshmu.dev/repoweb/joshmu/lab/README.md` returns `HTTP/2 200` with `content-type: text/plain` and the raw README body.
- [x] Confirmed `lab.joshmu.com` has no DNS record (`getent hosts` returns nothing).
- [x] `grep -rIn "joshmu\.com"` against the worktree returns no remaining matches after the change.

https://claude.ai/code/session_01PZ476JG2txpPoxzLdeDcSA